### PR TITLE
修复用户信息界面标题不匹配以及无法查看仓库根目录文件的问题

### DIFF
--- a/app/src/main/java/com/shuyu/github/kotlin/module/base/BaseUserInfoComponent.kt
+++ b/app/src/main/java/com/shuyu/github/kotlin/module/base/BaseUserInfoComponent.kt
@@ -104,7 +104,7 @@ abstract class BaseUserInfoViewModel constructor(private val userRepository: Use
             when (v?.id) {
                 R.id.user_header_repos -> {
                     GeneralListActivity.gotoGeneralList(this, "", login ?: ""+" "
-                    +application.getString(R.string.FollowedText), GeneralEnum.UserRepository, true)
+                    +application.getString(R.string.repositoryText), GeneralEnum.UserRepository, true)
                 }
                 R.id.user_header_fan -> {
                     GeneralListActivity.gotoGeneralList(this, "", login ?: ""+" "
@@ -116,7 +116,7 @@ abstract class BaseUserInfoViewModel constructor(private val userRepository: Use
                 }
                 R.id.user_header_star -> {
                     GeneralListActivity.gotoGeneralList(this, "", login ?: ""+" "
-                    +application.getString(R.string.FollowedText), GeneralEnum.UserStar)
+                    +application.getString(R.string.staredText), GeneralEnum.UserStar)
                 }
                 R.id.user_header_honor -> {
                     v.context.toast(R.string.user100Honor)

--- a/app/src/main/java/com/shuyu/github/kotlin/module/repos/file/ReposFileListFragment.kt
+++ b/app/src/main/java/com/shuyu/github/kotlin/module/repos/file/ReposFileListFragment.kt
@@ -56,8 +56,8 @@ class ReposFileListFragment : BaseListFragment<FragmentReposFileListBinding, Rep
                     val path = repos_file_select_header.list.toSplitString() + "/" + itemData.title
                     val url = CommonUtils.getFileHtmlUrl(userName, reposName, path) + "?raw=true"
                     CommonUtils.launchUrl(activity!!, url)
-                }else {
-                    CodeDetailActivity.gotoCodeDetail(userName, reposName, itemData.title, repos_file_select_header.list.toSplitString() + "/" + itemData.title)
+                } else {
+                    CodeDetailActivity.gotoCodeDetail(userName, reposName, itemData.title, (repos_file_select_header.list.toSplitString() + "/" + itemData.title).replace("/./", "/"))
                 }
             } else {
                 addSelectList(itemData.title)


### PR DESCRIPTION
- `BaseUserInfoComponent.kt` 中星标、粉丝、仓库三个子页面的标题文本原本都显示为“关注”，我已将它们正确替换

- `ReposFileListFragment.kt` 中调用`CodeDetailActivity.gotoCodeDetail`方法时对于仓库根目录的文件，如`/README.md`，会传入`/./README.md`的路径，导致无法预览文件，我将路径字符串中的"/./"替换为"/"以解决此问题